### PR TITLE
[Docs] Add OctoAcme Project Management README (central entry point)

### DIFF
--- a/docs/octoacme-project-management-readme.md
+++ b/docs/octoacme-project-management-readme.md
@@ -1,0 +1,34 @@
+# OctoAcme Project Management Docs — README
+
+Welcome to the OctoAcme Project Management documentation. This README provides a concise summary of how OctoAcme runs projects and links to the detailed process documents in this folder to help onboard new teammates and provide a single-entry point for project delivery practices.
+
+## Quick Overview of Project Management Processes
+- Principles: Customer-first, iterative delivery, clear ownership, data-informed decisions, psychological safety.
+- Lifecycle: Initiation → Planning → Execution → Release → Close & Retrospective.
+- Core Roles: Project Manager (PM), Product Manager (PdM), Developers, QA/Testing, Stakeholders.
+- Key Artifacts: Project One-pager/Charter, Roadmap & Release Plan, Prioritized Backlog, Acceptance Criteria & Definition of Done (DoD), Risk Register, Retrospectives and action items.
+- Communication Cadence: Daily standups (team), weekly PM+PdM sync, regular delivery demos, and monthly stakeholder updates. Escalation paths are defined (Team → PM → Product Lead → Sponsor).
+
+This README is intended as the single source-of-entry for process guidance — follow the links below for detailed templates, checklists, and playbooks.
+
+## Process Documents
+- [Project Management Overview](docs/octoacme-project-management-overview.md) — high-level approach, principles, roles, lifecycle, cadence.
+- [Project Initiation Guide](docs/octoacme-project-initiation.md) — one-pager template, initiation checklist, decision gate criteria.
+- [Project Planning](docs/octoacme-project-planning.md) — kickoff, backlog template, estimates, DoD, risk/dependency handling.
+- [Execution & Tracking](docs/octoacme-execution-and-tracking.md) — team rhythm, board/PR workflows, CI/QA expectations, metrics.
+- [Risk Management & Communication](docs/octoacme-risks-and-communication.md) — risk register lifecycle, stakeholder comms and templates, escalation.
+- [Release & Deployment Guide](docs/octoacme-release-and-deployment.md) — pre-release checklist, deployment steps, rollback & incident playbook.
+- [Retrospective & Continuous Improvement](docs/octoacme-retrospective-and-continuous-improvement.md) — retro structure, tracking action items, culture for incremental improvement.
+- [Roles & Personas](docs/octoacme-roles-and-personas.md) — role summaries and responsibilities for planning and exercises.
+
+## How to use this README
+- Use these documents as templates and living artifacts. Keep the Project One-pager and release notes updated in the project repo.
+- Add process-specific project details into `.copilot/` if you want Copilot Spaces to use them as context for role-specific assistance.
+- For onboarding, start with the Overview, then read the Initiation and Planning guides before joining Execution.
+
+## Acceptance Criteria for this README
+- Content aligns with existing process docs in docs/
+- README improves clarity and centralizes access for onboarding and reference
+- README links to all process documents in this folder
+
+If you want, I can also produce a tiny PR description + commit message and the exact branch name to use — see the commands below.


### PR DESCRIPTION
This PR adds docs/octoacme-project-management-readme.md to centralize OctoAcme project management guidance and link all process documents in docs/. 

Relates to: #2 